### PR TITLE
fix: waiting secret content before approve registration requests

### DIFF
--- a/pkg/controllermanager/approver/approver.go
+++ b/pkg/controllermanager/approver/approver.go
@@ -585,6 +585,14 @@ func getCredentialsForChildCluster(ctx context.Context, client *kubernetes.Clien
 		if lastError != nil {
 			return false, nil
 		}
+		if secret.Data[corev1.ServiceAccountTokenKey] == nil {
+			klog.Errorf("%s is nil in secret %s(%s)", corev1.ServiceAccountTokenKey, secretName, saNamespace)
+			return false, nil
+		}
+		if secret.Data[corev1.ServiceAccountRootCAKey] == nil {
+			klog.Errorf("%s is nil in secret %s(%s)", corev1.ServiceAccountRootCAKey, secretName, saNamespace)
+			return false, nil
+		}
 		return true, nil
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

Sometimes the clusterregistrationrequests is approved, but the token and caCertificate is empty. The token and caCertificate is come from a secret, so we need check the secret content before approve the clusterregistrationrequests.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
